### PR TITLE
amd support

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -483,7 +483,11 @@ rbush.prototype = {
     }
 };
 
-if (typeof module !== 'undefined') {
+if (typeof define === 'function' && define.amd) {
+    define(function() {
+        return rbush;
+    });
+} else if (typeof module !== 'undefined') {
     module.exports = rbush;
 } else {
     window.rbush = rbush;


### PR DESCRIPTION
Here's a little PR for AMD support.  Like Leaflet, there is no need for a dependency array.  Unlike Leaflet, the module export is a function, so it needs to be returned via an anonymous function instead of the shorter `define(rbush)`.

Thanks for making rbush!
