### PR TITLE
Don't use window object

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -491,7 +491,7 @@ if (typeof define === 'function' && define.amd) {
 } else if (typeof module !== 'undefined') {
     module.exports = rbush;
 } else {
-    self.rbush = rbush;
+    this.rbush = rbush;
 }
 
 })();


### PR DESCRIPTION
The window object doesn't exist in all JavaScript contexts, e.g. Web workers.
