### PR TITLE
Avoid using function constructor for alt format handling

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -471,20 +471,34 @@ rbush.prototype = {
 
     _initFormat: function (format) {
         // data format (minX, minY, maxX, maxY accessors)
-        format = format || ['[0]', '[1]', '[2]', '[3]'];
+        if (format) {
+            // support old style of providing `.foo` or `[0]` accessors
+            var reg = /^[\.\[]?(.*?)\]?$/,
+                i;
 
-        // uses eval-type function compilation instead of just accepting a toBBox function
-        // because the algorithms are very sensitive to sorting functions performance,
-        // so they should be dead simple and without inner calls
+            for (i = 0; i < 4; ++i) {
+                format[i] = format[i].toString().replace(reg, '$1');
+            }
+        } else {
+            format = [0, 1, 2, 3];
+        }
 
-        // jshint evil: true
+        var minXProp = format[0],
+            minYProp = format[1],
+            maxXProp = format[2],
+            maxYProp = format[3];
 
-        var compareArr = ['return a', ' - b', ';'];
+        this._compareMinX = function (a, b) {
+            return a[minXProp] - b[minXProp];
+        };
 
-        this._compareMinX = new Function('a', 'b', compareArr.join(format[0]));
-        this._compareMinY = new Function('a', 'b', compareArr.join(format[1]));
+        this._compareMinY = function (a, b) {
+            return a[minYProp] - b[minYProp];
+        };
 
-        this._toBBox = new Function('a', 'return [a' + format.join(', a') + '];');
+        this._toBBox = function (a) {
+            return [a[minXProp], a[minYProp], a[maxXProp], a[maxYProp]];
+        };
     }
 };
 

--- a/test/test.js
+++ b/test/test.js
@@ -36,9 +36,28 @@ describe('rbush', function () {
     describe('constructor', function () {
         it('accepts a format argument to customize the data format', function () {
 
+            var tree = rbush(4, ['minLng', 'minLat', 'maxLng', 'maxLat']);
+            assert.deepEqual(tree._toBBox({minLng: 1, minLat: 2, maxLng: 3, maxLat: 4}), [1, 2, 3, 4]);
+        });
+
+        it('accepts numeric property accessors', function () {
+
+            var tree = rbush(4, [0, 2, 1, 3]);
+            assert.deepEqual(tree._toBBox([-180, 180, -90, 90]), [-180, -90, 180, 90]);
+        });
+
+        it('accepts a dot prefixed property names', function () {
+
             var tree = rbush(4, ['.minLng', '.minLat', '.maxLng', '.maxLat']);
             assert.deepEqual(tree._toBBox({minLng: 1, minLat: 2, maxLng: 3, maxLat: 4}), [1, 2, 3, 4]);
         });
+
+        it('accepts bracket wrapped property names', function () {
+
+            var tree = rbush(4, ['[0]', '[2]', '[1]', '[3]']);
+            assert.deepEqual(tree._toBBox([-180, 180, -90, 90]), [-180, -90, 180, 90]);
+        });
+
     });
 
     describe('load', function () {


### PR DESCRIPTION
This allows rbush to be used where the Content Security Policy (or other) disallows the use of eval and related functions (e.g. browser extensions).  Previously, the format supplied could contain function calls (e.g. `['.getMaxX()', ...]`).  With this change, only property names are accepted - though they can be dot prefixed or bracket wrapped (e.g. `'.maxX'` or `'[0]'`).
