### PR TITLE
Basic instructions on running tests and performance benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,17 @@ e.g. first indexing the data on the server and and then importing the resulting 
 * [OMT: Overlap Minimizing Top-down Bulk Loading Algorithm for R-tree](http://ftp.informatik.rwth-aachen.de/Publications/CEUR-WS/Vol-74/files/FORUM_18.pdf)
 * [Bulk Insertions into R-Trees Using the Small-Tree-Large-Tree Approach](http://www.cs.arizona.edu/~bkmoon/papers/dke06-bulk.pdf)
 * [R-Trees: Theory and Applications (book)](http://metro-natshar-31-71.brain.net.pk/articles/1852339772.pdf)
+
+## Development
+
+Install to get package dependencies:
+
+    npm install
+
+Run the tests:
+
+    npm test
+
+Run the performance benchmarks:
+
+    npm run perf

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
   },
   "main": "rbush.js",
   "devDependencies": {
-    "mocha": "~1.13.0"
+    "mocha": "~1.13.0",
+    "rtree": "~1.2.3"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha",
+    "perf": "node ./debug/perf.js"
   }
 }


### PR DESCRIPTION
As described in the readme, tests are run with `npm run` and the performance benchmarks can be run with `npm run perf` (without having a global install of `rtree`).
