### PR TITLE
Encourage override of toBBox, compareMinX, compareMinY for CSP issues

### DIFF
--- a/viz/viz.js
+++ b/viz/viz.js
@@ -83,7 +83,7 @@ function search(e) {
 }
 
 function remove() {
-    data.sort(tree._compareMinX);
+    data.sort(tree.compareMinX);
     console.time('remove 10000');
     for (var i = 0; i < 10000; i++) {
         tree.remove(data[i]);


### PR DESCRIPTION
Where the Content Security Policy (or other) disallows the use of eval and related functions (e.g. browser extensions), the `toBBox`, `compareMinX`, and `compareMinY` methods can be overridden.

This makes it so the `Function` constructor is only used if a custom format is supplied.  Default implementations of `toBBox`, `compareMinX`, and `compareMinY` are run otherwise.

This is an alternative to #12 (and doesn't break the current API).
