### PR TITLE
Fix loop condition in _allDistMargin

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -408,7 +408,7 @@ rbush.prototype = {
             margin += this._margin(leftBBox);
         }
 
-        for (i = M - m - 1; i >= 0; i--) {
+        for (i = M - m - 1; i >= m; i--) {
             child = node.children[i];
             this._extend(rightBBox, node.leaf ? this.toBBox(child) : child.bbox);
             margin += this._margin(rightBBox);


### PR DESCRIPTION
I think this fixes a bug in `_allDistMargin`. In the existing code, compare [the loop condition for `leftBBox`](https://github.com/mourner/rbush/blob/master/rbush.js#L405) with [the loop condition for `rightBBox`](https://github.com/mourner/rbush/blob/master/rbush.js#L411):

``` javascript
for (i = m; i < M - m; i++) { // leftBBox
    // ...
}
```

``` javascript
for (i = M - m - 1; i >= 0; i--) { // rightBBox
    // ...
}
```

The code for `rightBBox` completes more iterations. I think the code should be symmetrical with both loops completing the same number of iterations. I think the attached patch fixes this by making the `rightBBox` loop match the `leftBBox` loop.
