### PR TITLE
Speed up remove by about 50%

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -147,7 +147,7 @@ rbush.prototype = {
                 }
             }
 
-            if (!goingUp && !node.leaf && this._intersects(bbox, node.bbox)) { // go down
+            if (!goingUp && !node.leaf && this._contains(node.bbox, bbox)) { // go down
                 path.push(node);
                 indexes.push(i);
                 i = 0;


### PR DESCRIPTION
A node's bbox is the union of its children's bboxes.  When searching for a node with a specific extent, the node can only be in children who's bboxes strictly contain the node's extent.  We can therefore replace the intersection test with a stricter contains test.  This improves the speed of remove by about 50%.
