### PR TITLE
fixes requirejs optimization

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -579,7 +579,7 @@ function swap(arr, i, j) {
 
 
 // export as AMD/CommonJS module or global variable
-if (typeof define === 'function' && define.amd) define(function() { return rbush; });
+if (typeof define === 'function' && define.amd) define('rbush', function() { return rbush; });
 else if (typeof module !== 'undefined') module.exports = rbush;
 else if (typeof self !== 'undefined') self.rbush = rbush;
 else window.rbush = rbush;


### PR DESCRIPTION
Hi,

I've been trying to bundle ol3 with my app using requirejs optimizer.
I ran into a runtime error :

>Mismatched anonymous define() modules ...

After some research, I found that in my ol.js file, the rbush dependency was defined without name:

    // export as AMD/CommonJS module or global variable 
    if (typeof define === 'function' && define.amd) define(function() { return rbush; }); 

Or that generate an issue in requireJS:

>If you use the loader plugins or anonymous modules (modules that call define() with no string ID) but do not use the RequireJS optimizer to combine files together, this error can occur. 

I modified the source likewise in order to avoid that error:

    // export as AMD/CommonJS module or global variable 
     if (typeof define === 'function' && define.amd) define("rbush", function() { return rbush; });