### PR TITLE
Fix splice for ES3 compat

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -340,8 +340,10 @@ rbush.prototype = {
 
         this._chooseSplitAxis(node, m, M);
 
+        var splitIndex = this._chooseSplitIndex(node, m, M);
+
         var newNode = {
-            children: node.children.splice(this._chooseSplitIndex(node, m, M)),
+            children: node.children.splice(splitIndex, node.children.length - splitIndex),
             height: node.height
         };
 


### PR DESCRIPTION
@IvanSanchez can you check #31 test case on this branch? Should work in theory. Then we'd just update readme with something like "works everywhere, but `remove` depends on `Array.indexOf` polyfill for IE8 and earlier".