### PR TITLE
Accept equalsFn in remove

### DIFF
--- a/rbush.js
+++ b/rbush.js
@@ -129,7 +129,7 @@ rbush.prototype = {
         return this;
     },
 
-    remove: function (item) {
+    remove: function (item, equalsFn) {
         if (!item) return this;
 
         var node = this.data,
@@ -149,7 +149,7 @@ rbush.prototype = {
             }
 
             if (node.leaf) { // check current node
-                index = node.children.indexOf(item);
+                index = findItem(item, node.children, equalsFn);
 
                 if (index !== -1) {
                     // item found, remove the item and condense tree upwards
@@ -458,6 +458,14 @@ rbush.prototype = {
     }
 };
 
+function findItem(item, items, equalsFn) {
+    if (!equalsFn) return items.indexOf(item);
+
+    for (var i = 0; i < items.length; i++) {
+        if (equalsFn(item, items[i])) return i;
+    }
+    return -1;
+}
 
 // calculate node's bbox from bboxes of its children
 function calcBBox(node, toBBox) {

--- a/test/test.js
+++ b/test/test.js
@@ -346,6 +346,19 @@ t('#remove brings the tree to a clear state when removing everything one by one'
     t.same(tree.toJSON(), rbush(4).toJSON());
     t.end();
 });
+t('#remove accepts an equals function', function (t) {
+    var tree = rbush(4).load(data);
+
+    var item = {minX: 20, minY: 70, maxX: 20, maxY: 70, foo: 'bar'};
+
+    tree.insert(item);
+    tree.remove(JSON.parse(JSON.stringify(item)), function (a, b) {
+        return a.foo === b.foo;
+    });
+
+    sortedEqual(t, tree.all(), data);
+    t.end();
+});
 
 t('#clear should clear all the data in the tree', function (t) {
     t.same(


### PR DESCRIPTION
Closes #22 by allowing you to specify a custom equals function as a second argument to `remove`. By default, RBush will still compare by reference, by you will also be able to do this:

```js
tree.remove(item, function (a, b) {
    return a.id === b.id;
});
```

cc @calvinmetcalf