### PR TITLE
fix typo in inline comment

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ rbush.prototype = {
             return this;
         }
 
-        // recursively build the tree with the given data from stratch using OMT algorithm
+        // recursively build the tree with the given data from scratch using OMT algorithm
         var node = this._build(data.slice(), 0, data.length - 1, 0);
 
         if (!this.data.children.length) {


### PR DESCRIPTION
`¯\_(ツ)_/¯`