### PR TITLE
Enable using Symbols for custom object property format.

### DIFF
--- a/bench/perf.js
+++ b/bench/perf.js
@@ -1,20 +1,49 @@
 'use strict';
 
+var rbush = typeof require !== 'undefined' ? require('..') : rbush;
+var args = require('minimist')(process.argv.slice(2));
+
 var N = 1000000,
     maxFill = 16;
 
+console.log('using custom format: ' + (!!args['format'] ? 'yes' : 'no'));
 console.log('number: ' + N);
 console.log('maxFill: ' + maxFill);
 
-function randBox(size) {
-    var x = Math.random() * (100 - size),
-        y = Math.random() * (100 - size);
-    return {
-        minX: x,
-        minY: y,
-        maxX: x + size * Math.random(),
-        maxY: y + size * Math.random()
-    };
+var randBox = null;
+var tree = null;
+
+if (args['format']) {
+
+    const minX = Symbol();
+    const minY = Symbol();
+    const maxX = Symbol();
+    const maxY = Symbol();
+
+	tree = rbush(maxFill, [minX, minY, maxX, maxY]);
+	randBox = function (size) {
+		var x = Math.random() * (100 - size),
+			y = Math.random() * (100 - size);
+		return {
+			[minX]: x,
+			[minY]: y,
+			[maxX]: x + size * Math.random(),
+			[maxY]: y + size * Math.random()
+		};
+	};
+}
+else {
+	tree = rbush(maxFill);
+	randBox = function (size) {
+		var x = Math.random() * (100 - size),
+			y = Math.random() * (100 - size);
+		return {
+			minX: x,
+			minY: y,
+			maxX: x + size * Math.random(),
+			maxY: y + size * Math.random()
+		};
+	}
 }
 
 function genData(N, size) {
@@ -30,10 +59,6 @@ var data2 = genData(N, 1);
 var bboxes100 = genData(1000, 100 * Math.sqrt(0.1));
 var bboxes10 = genData(1000, 10);
 var bboxes1 = genData(1000, 1);
-
-var rbush = typeof require !== 'undefined' ? require('..') : rbush;
-
-var tree = rbush(maxFill);
 
 console.time('insert one by one');
 for (var i = 0; i < N; i++) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-config-mourner": "^2.0.1",
     "faucet": "0.0.1",
     "istanbul": "~0.4.3",
+    "minimist": "^1.2.0",
     "tape": "^4.5.1",
     "uglify-js": "^2.6.4"
   },


### PR DESCRIPTION
Hello,

Love this module!

Why:
However, in the project that I am working at right, it is impossible to define property names as strings for the class of objects that will be used with rbush.

How:
To solve this problem I have re-factored rbush '_initFormat' function to allow for all legal property identifiers to be valid.

Instead of relying on rbush users to provide both property access notation and property name it will now only accept property identifier array and will access properties on the boxed object using bracket notation only.

Note: I thought it would be nice not to break all of the users of rbush and added backward compatibility in there too :)

Bonus:
Looking at the performance test, the variant without custom format did not change. However judging by several consecutive tests, the variant where I set custom rbush forma both for strings and Symbols show a considerable boost in its performance readouts...

Tests runs on : node v6.8.1 on AMD Fx-8320 3.51GHz

before:
![before](https://cloud.githubusercontent.com/assets/3842466/23782041/51030dc2-05b6-11e7-92fe-150558858126.PNG)

after (top test is vanilla format variant and bottom is with custom format)
![after](https://cloud.githubusercontent.com/assets/3842466/23782171/2018c034-05b7-11e7-900a-f644646c8370.PNG)

Cheers

Please let me know if there is anything that I should change/update/improve regarding this pull request.
