### PR TITLE
Allow toBBox to be extended

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ rbush.prototype = {
         var node = this.data,
             result = [],
             toBBox = this.toBBox;
+        bbox = toBBox(bbox);
 
         if (!intersects(bbox, node)) return result;
 
@@ -57,6 +58,7 @@ rbush.prototype = {
 
         var node = this.data,
             toBBox = this.toBBox;
+        bbox = toBBox(bbox)
 
         if (!intersects(bbox, node)) return false;
 

--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ rbush.prototype = {
 
         var node = this.data,
             toBBox = this.toBBox;
-        bbox = toBBox(bbox)
+        bbox = toBBox(bbox);
 
         if (!intersects(bbox, node)) return false;
 


### PR DESCRIPTION
@mourner These two minor line changes will make a huge difference to extend both `search()` & `collide()` while using a custom BBox formatter (what I'm currently attempting to do for `@turf/index`).

Here's an example of extending RBush using GeoJSON.

```javascript
var bbox = require('@turf/bbox')

rbush.prototype.toBBox = function (item) {
    var bbox = item.bbox ? item.bbox : bbox(item);
    return {
        minX: bbox[0],
        minY: bbox[1],
        maxX: bbox[2],
        maxY: bbox[3]
    }
}
```
This wont' impact any performance since the default `toBBox()` simply returns the input given.