### PR TITLE
#search accepts `delete` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ Returns an array of data items (points or rectangles) that the given bounding bo
 Note that the `search` method accepts a bounding box in `{minX, minY, maxX, maxY}` format
 regardless of the format specified in the constructor (which only affects inserted objects).
 
+Search accepts options object, where you can specify if returned result should be deleted from
+index:
+```js
+var result = tree.search({
+  minX: 40,
+  minY: 20,
+  maxX: 80,
+  maxY: 70
+}, { delete: true });
+````
+Example above deletes returned result from index right upon search, thus ensuring that
+you will never get the returned result in sebsequent search queries. It works more
+effectively than either memoization and filtering (checking if results have been already returned before)
+or deleting results one by one using `delete` method call.
+
 ```js
 var allItems = tree.all();
 ```

--- a/bench/perf.js
+++ b/bench/perf.js
@@ -47,11 +47,27 @@ for (i = 0; i < 1000; i++) {
 }
 console.timeEnd('1000 searches 10%');
 
+console.time('1000 searches 10% with delete');
+for (i = 0; i < 1000; i++) {
+    tree.search(bboxes100[i], { delete: true });
+}
+console.timeEnd('1000 searches 10% with delete');
+
+tree = rbush(maxFill);
+
 console.time('1000 searches 1%');
 for (i = 0; i < 1000; i++) {
     tree.search(bboxes10[i]);
 }
 console.timeEnd('1000 searches 1%');
+
+console.time('1000 searches 1% with delete');
+for (i = 0; i < 1000; i++) {
+    tree.search(bboxes10[i], { delete: true });
+}
+console.timeEnd('1000 searches 1% with delete');
+
+tree = rbush(maxFill);
 
 console.time('1000 searches 0.01%');
 for (i = 0; i < 1000; i++) {

--- a/index.js
+++ b/index.js
@@ -208,10 +208,10 @@ rbush.prototype = {
                 path.push(node);
             }
             if (node.leaf) {
+                result.push.apply(result, node.children);
                 if (path) {
                     node.children = [];
                 }
-                result.push.apply(result, node.children);
             } else nodesToSearch.push.apply(nodesToSearch, node.children);
 
             node = nodesToSearch.pop();

--- a/test/test.js
+++ b/test/test.js
@@ -413,3 +413,19 @@ t('#search accepts option to delete results: exclude previous result', function 
     ].map(arrToBBox));
     t.end();
 });
+
+t('#search accepts option to delete results: subsequent exclude', function (t) {
+    var tree = rbush(4).load(data);
+    tree.search({minX: 40, minY: 20, maxX: 80, maxY: 70}, {
+        delete: true
+    });
+    tree.search({minX: 35, minY: 20, maxX: 80, maxY: 70}, {
+        delete: true
+    });
+    var result = tree.search({minX: 35, minY: 20, maxX: 80, maxY: 70}, {
+        delete: true
+    });
+    t.equal(result.length, 0);
+
+    t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -376,3 +376,40 @@ t('should have chainable API', function (t) {
     });
     t.end();
 });
+
+t('#search accepts option to delete results: subsequent call', function (t) {
+    var tree = rbush(4).load(data);
+    var result = tree.search({minX: 40, minY: 20, maxX: 80, maxY: 70}, {
+        delete: true
+    });
+
+    sortedEqual(t, result, [
+        [70,20,70,20],[75,25,75,25],[45,45,45,45],[50,50,50,50],[60,60,60,60],[70,70,70,70],
+        [45,20,45,20],[45,70,45,70],[75,50,75,50],[50,25,50,25],[60,35,60,35],[70,45,70,45]
+    ].map(arrToBBox));
+
+    result = tree.search({minX: 40, minY: 20, maxX: 80, maxY: 70});
+
+    t.equal(result, []);
+    t.end();
+});
+
+t('#search accepts option to delete results: exclude previous result', function (t) {
+    var tree = rbush(4).load(data);
+    var result = tree.search({minX: 40, minY: 20, maxX: 80, maxY: 70}, {
+        delete: true
+    });
+
+    sortedEqual(t, result, [
+        [70,20,70,20],[75,25,75,25],[45,45,45,45],[50,50,50,50],[60,60,60,60],[70,70,70,70],
+        [45,20,45,20],[45,70,45,70],[75,50,75,50],[50,25,50,25],[60,35,60,35],[70,45,70,45]
+    ].map(arrToBBox));
+
+    result = tree.search({minX: 35, minY: 20, maxX: 80, maxY: 70});
+
+    t.equal(result.length, 2);
+    sortedEqual(t, result, [
+        [35, 35, 35, 35 ], [35, 60, 35, 60]
+    ].map(arrToBBox));
+    t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -390,7 +390,7 @@ t('#search accepts option to delete results: subsequent call', function (t) {
 
     result = tree.search({minX: 40, minY: 20, maxX: 80, maxY: 70});
 
-    t.equal(result, []);
+    t.equal(result.length, 0);
     t.end();
 });
 
@@ -409,7 +409,7 @@ t('#search accepts option to delete results: exclude previous result', function 
 
     t.equal(result.length, 2);
     sortedEqual(t, result, [
-        [35, 35, 35, 35 ], [35, 60, 35, 60]
+        [35, 35, 35, 35], [35, 60, 35, 60]
     ].map(arrToBBox));
     t.end();
 });


### PR DESCRIPTION
@mourner thanks for this great library!

The use case for my PR is when you have a map with lot of dots, user navigates the map moving bounding box rectangle, and dots are loaded lazily using client side RBush index. So when user moves the map, I don't wanna re-fetch already displayed dots, I just wanna query those from index that are not yet present (rendered) on the map.

Please lmk what do you think. Thank you.