### PR TITLE
Make rbush an ES6 library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ coverage
 .nyc_output
 rbush.js
 rbush.min.js
-rbush.es.js

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ npm-debug.log
 coverage
 rbush.js
 rbush.min.js
+rbush.es.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 npm-debug.log
 coverage
+.nyc_output
 rbush.js
 rbush.min.js
 rbush.es.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - "4"
+  - "8"
   - "stable"

--- a/bench/perf.js
+++ b/bench/perf.js
@@ -1,4 +1,4 @@
-'use strict';
+import rbush from '..';
 
 var N = 1000000,
     maxFill = 16;
@@ -30,8 +30,6 @@ var data2 = genData(N, 1);
 var bboxes100 = genData(1000, 100 * Math.sqrt(0.1));
 var bboxes10 = genData(1000, 10);
 var bboxes1 = genData(1000, 1);
-
-var rbush = typeof require !== 'undefined' ? require('..') : rbush;
 
 var tree = rbush(maxFill);
 

--- a/index.js
+++ b/index.js
@@ -1,11 +1,6 @@
-'use strict';
+import quickselect from 'quickselect';
 
-module.exports = rbush;
-module.exports.default = rbush;
-
-var quickselect = require('quickselect');
-
-function rbush(maxEntries, format) {
+export default function rbush(maxEntries, format) {
     if (!(this instanceof rbush)) return new rbush(maxEntries, format);
 
     // max entries in a node is 9 by default; min node fill is 40% for best performance

--- a/package.json
+++ b/package.json
@@ -18,38 +18,45 @@
   "author": "Vladimir Agafonkin",
   "license": "MIT",
   "main": "index.js",
+  "module": "index.js",
+  "browser": "rbush.js",
   "jsdelivr": "rbush.js",
   "unpkg": "rbush.js",
   "devDependencies": {
     "benchmark": "^2.1.4",
-    "browserify": "^14.5.0",
     "eslint": "^4.13.1",
     "eslint-config-mourner": "^2.0.3",
+    "esm": "^3.0.84",
     "faucet": "0.0.1",
-    "istanbul": "~0.4.5",
-    "tape": "^4.8.0",
-    "uglify-js": "^3.2.2"
+    "nyc": "^13.1.0",
+    "rollup": "^0.67.3",
+    "rollup-plugin-node-resolve": "^3.4.0",
+    "rollup-plugin-uglify": "^6.0.0",
+    "tape": "^4.8.0"
   },
   "scripts": {
-    "test": "eslint index.js test/test.js && node test/test.js | faucet",
-    "perf": "node ./bench/perf.js",
-    "cov": "istanbul cover test/test.js -x test/test.js",
-    "build": "browserify index.js -s rbush -o rbush.js",
-    "build-min": "browserify index.js -s rbush | uglifyjs -c warnings=false -m > rbush.min.js",
-    "prepare": "npm run build && npm run build-min"
+    "test": "eslint index.js test/test.js && node -r esm test/test.js | faucet",
+    "perf": "node -r esm ./bench/perf.js",
+    "cov": "nyc --check-coverage --require esm npm test",
+    "build": "rollup -c",
+    "prepare": "npm run build"
   },
   "files": [
     "rbush.js",
-    "rbush.min.js"
+    "rbush.min.js",
+    "rbush.es.js"
   ],
   "eslintConfig": {
     "extends": "mourner",
+    "parserOptions": {
+      "sourceType": "module"
+    },
     "rules": {
       "new-cap": 0,
       "consistent-return": 0
     }
   },
   "dependencies": {
-    "quickselect": "^1.0.1"
+    "quickselect": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,11 @@
   ],
   "author": "Vladimir Agafonkin",
   "license": "MIT",
-  "main": "index.js",
+  "main": "rbush.js",
   "module": "index.js",
-  "browser": "rbush.js",
-  "jsdelivr": "rbush.js",
-  "unpkg": "rbush.js",
+  "browser": "rbush.min.js",
+  "jsdelivr": "rbush.min.js",
+  "unpkg": "rbush.min.js",
   "devDependencies": {
     "benchmark": "^2.1.4",
     "eslint": "^4.13.1",
@@ -31,20 +31,22 @@
     "nyc": "^13.1.0",
     "rollup": "^0.67.3",
     "rollup-plugin-node-resolve": "^3.4.0",
-    "rollup-plugin-uglify": "^6.0.0",
+    "rollup-plugin-terser": "^3.0.0",
     "tape": "^4.8.0"
   },
   "scripts": {
-    "test": "eslint index.js test/test.js && node -r esm test/test.js | faucet",
+    "pretest": "eslint index.js test/test.js ",
+    "test": "node -r esm test/test.js | faucet",
     "perf": "node -r esm ./bench/perf.js",
     "cov": "nyc --check-coverage --require esm npm test",
     "build": "rollup -c",
-    "prepare": "npm run build"
+    "prepare": "npm run build",
+    "prepublishOnly": "npm run build"
   },
   "files": [
+    "index.js",
     "rbush.js",
-    "rbush.min.js",
-    "rbush.es.js"
+    "rbush.min.js"
   ],
   "eslintConfig": {
     "extends": "mourner",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,25 @@
+import {uglify} from 'rollup-plugin-uglify';
+import resolve from 'rollup-plugin-node-resolve';
+
+export default [{
+    input: 'index.js',
+    output: [{
+        name: 'rbush',
+        format: 'umd',
+        file: 'rbush.js',
+        indent: false
+    }, {
+        file: 'rbush.es.js',
+        format: 'es'
+    }],
+    plugins: [resolve()]
+},
+{
+    input: 'index.js',
+    output: {
+        name: 'rbush',
+        format: 'umd',
+        file: 'rbush.min.js',
+    },
+    plugins: [resolve(), uglify()]
+}];

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,25 +1,17 @@
-import {uglify} from 'rollup-plugin-uglify';
+import {terser} from 'rollup-plugin-terser';
 import resolve from 'rollup-plugin-node-resolve';
 
-export default [{
-    input: 'index.js',
-    output: [{
-        name: 'rbush',
-        format: 'umd',
-        file: 'rbush.js',
-        indent: false
-    }, {
-        file: 'rbush.es.js',
-        format: 'es'
-    }],
-    plugins: [resolve()]
-},
-{
+const output = (file, plugins) => ({
     input: 'index.js',
     output: {
         name: 'rbush',
         format: 'umd',
-        file: 'rbush.min.js',
+        file
     },
-    plugins: [resolve(), uglify()]
-}];
+    plugins
+});
+
+export default [
+    output('rbush.js', [resolve()]),
+    output('rbush.min.js', [resolve(), terser()])
+];

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,8 @@
-'use strict';
 
 /*eslint key-spacing: 0, comma-spacing: 0 */
 
-var rbush = require('..'),
-    t = require('tape');
+import rbush from '..';
+import t from 'tape';
 
 function sortedEqual(t, a, b, compare) {
     compare = compare || defaultCompare;


### PR DESCRIPTION
Hi @mourner 

I didn't get a response on #88 but figured I'd proceed with throwing together a pull request anyway given that it wasn't a huge amount of work, so hopefully you're happy to accept it :)

The reason I'm pretty keen for this is to support TurfJS as we're trying to make everything ES6 and tree-shaking is problematic unless our dependencies are ES6 as well.

Most things should be fairly similar to how you'd set them up for `quickselect`, probably the primary thing I changed was moving from `instanbul` to `nyc` for the coverage tests - I can't confess to know a huge amount about that coverage ecosystem but hopefully what I've done makes sense.

Let me know if you have any questions or concerns.
Thanks,
Rowan 