### PR TITLE
Ensure _chooseSplitIndex always return a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -346,7 +346,7 @@ export default class RBush {
             }
         }
 
-        return index;
+        return index || M - m;
     }
 
     // sorts node children by the best axis for split

--- a/test/test.js
+++ b/test/test.js
@@ -174,6 +174,8 @@ t('#insert handles the insertion of maxEntries + 2 empty bboxes', (t) => {
 
     t.equal(tree.toJSON().height, 2);
     sortedEqual(t, tree.all(), emptyData);
+    t.equal(tree.data.children[0].children.length, 4);
+    t.equal(tree.data.children[1].children.length, 2);
 
     t.end();
 });


### PR DESCRIPTION
Fix #69

Current implementation of `_chooseSplitIndex` may return undefined when all children have infinity area.

When all inserted rects are infinity, they will be all inserted in a single node, instead of properly balancing the tree (updated test to validate this).

When data is random, an incorrect split may occur in a non-leaf node, causing a non-leaf node to have 0 children and causing error #69 when the tree will try to insert new data in its path.

This fix ensure that `_chooseSplitIndex` always return a number.