### PR TITLE
readme: hilight remove fn assumes coords not changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ Remove all items:
 tree.clear();
 ```
 
+**warning**
+
+The remove implementation relies on the coordinates of the object to be the same as when it was inserted.
+This is because the fn is optimised to only look for the object to remove in the sections of the tree it expects them to be in, based on the coordinates of the item being removed.
+
+This will cause issues
+
+```js
+    
+// bad    
+obj.minX += 5
+obj.maxX -= 5
+tree.remove(obj)
+tree.insert(obj)
+
+// you may end up with two copies of the object
+
+// good    
+tree.remove(obj)
+obj.minX += 5
+obj.maxX -= 5
+tree.insert(obj)
+``` 
+
 ### Data Format
 
 By default, RBush assumes the format of data points to be an object


### PR DESCRIPTION
Thank you for the great library !

I am using it in https://github.com/Displayr/rhtmlLabeledScatter which is a scatter / bubble plot library I have inherited and am heavily recfactoring. rbush has helped me clean up the collision detection logic used in the label placement algorithm.

I came across what I initially thought was a bug, but upon investigation it was me incorrectly using rbush.

The use case is that I am constantly moving the labels around, and checking for collisions. I observed that the remove call would not always remove the label rectangle. Upon investigating the remove implementation i realise that it optimises its tree traversal logic based on assumptions about the coordinates of the label rectangle. So if I change the x/y coords then call remove, sometimes the object would not get removed from the tree ! 

See the updates to the docs I made to hopefully save others some time. 
Happy to change wording/format etc.