### PR TITLE
Transpile ES6 features except import/ export in module

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Vladimir Agafonkin",
   "license": "MIT",
   "main": "rbush.js",
-  "module": "index.js",
+  "module": "rbush.esm.js",
   "browser": "rbush.min.js",
   "jsdelivr": "rbush.min.js",
   "unpkg": "rbush.min.js",
@@ -45,7 +45,8 @@
   "files": [
     "index.js",
     "rbush.js",
-    "rbush.min.js"
+    "rbush.min.js",
+    "rbush.esm.js"
   ],
   "eslintConfig": {
     "extends": "mourner"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,8 +1,9 @@
 import {terser} from 'rollup-plugin-terser';
 import resolve from '@rollup/plugin-node-resolve';
 import buble from '@rollup/plugin-buble';
+import pkg from './package.json';
 
-const output = (file, plugins) => ({
+const umd = (file, plugins) => ({
     input: 'index.js',
     output: {
         name: 'RBush',
@@ -13,7 +14,18 @@ const output = (file, plugins) => ({
     plugins
 });
 
+const esm = (file, plugins) => ({
+    input: 'index.js',
+    output: {
+        format: 'esm',
+        file
+    },
+    external: Object.keys(pkg.dependencies),
+    plugins
+});
+
 export default [
-    output('rbush.js', [resolve(), buble()]),
-    output('rbush.min.js', [resolve(), buble(), terser()])
+    umd('rbush.js', [resolve(), buble()]),
+    umd('rbush.min.js', [resolve(), buble(), terser()]),
+    esm('rbush.esm.js', [buble()])
 ];


### PR DESCRIPTION
Currently `package.json` specifies `index.js` as the `module`; `index.js` includes ES6 features that require transpiling to ES5 to support older environments. The new `rbush.esm.js` includes `import`/ `export` statements but all other ES6 features are transpiled following the advice here: [pkg.module](https://github.com/rollup/rollup/wiki/pkg.module#wait-it-just-means-import-and-export--not-other-future-javascript-features).