### PR TITLE
Conditional export support

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   "browser": "rbush.min.js",
   "jsdelivr": "rbush.min.js",
   "unpkg": "rbush.min.js",
+  "exports": {
+    "import": "./index.js",
+    "require":  "./rbush.min.js"
+  },
   "devDependencies": {
     "@rollup/plugin-buble": "^0.21.1",
     "@rollup/plugin-node-resolve": "^7.1.1",


### PR DESCRIPTION
Hi @mourner,

thank you for the great lib! 

I'm faced with the issue of using it with VITE (yet another js bundler) which is using *next* version of rollup behind the scene.
The problem is that importing your ESM module from 3rd party modules (CJS) causes issues because of the wrong interoperability (`export default` doesn't work correctly in this case).

I propose to improve your lib by using conditional export, please have a look! 

(I checked now it works with Vite and rollup) 

Ref: https://nodejs.org/api/packages.html#packages_conditional_exports

 Cheers,
Maxim Kotelnikov